### PR TITLE
deleteTrackingCookies does delete cookie now

### DIFF
--- a/cookies-cnil-banner.js
+++ b/cookies-cnil-banner.js
@@ -97,9 +97,9 @@ var CookiesCnilBanner;
          * Delete existants tracking cookies
          */
         deleteTrackingCookies: function(){
-            var name;
-            for(name in this.trackingCookiesNames){
-                this.deleteCookie(name);
+            var nameId;
+            for(nameId in this.trackingCookiesNames){
+                this.deleteCookie(this.trackingCookiesNames[nameId]);
             }
         },
 


### PR DESCRIPTION
deleteTrackingCookies did not delete cookie as the 'name' variable contained the id in the array of trackingCookiesNames and was sent to deleteCookie function that did not found the cookie as it was a number and not a name...

So it is fixed in this version...